### PR TITLE
Change thrown exception type in Window's class constructor

### DIFF
--- a/NoiseEngine.Native/src/errors/mod.rs
+++ b/NoiseEngine.Native/src/errors/mod.rs
@@ -4,3 +4,4 @@ pub mod conversions;
 pub mod invalid_operation;
 pub mod null_reference;
 pub mod overflow;
+pub mod platform_not_supported;

--- a/NoiseEngine.Native/src/errors/platform_not_supported.rs
+++ b/NoiseEngine.Native/src/errors/platform_not_supported.rs
@@ -1,0 +1,44 @@
+use std::{error::Error, fmt::Display};
+
+use crate::interop::prelude::{ResultError, ResultErrorKind};
+
+#[derive(Debug)]
+pub struct PlatformNotSupportedError {
+    message: String,
+}
+
+impl PlatformNotSupportedError {
+    pub fn new(message: String) -> Self {
+        Self { message }
+    }
+
+    pub fn with_str(message: &str) -> Self {
+        Self::new(message.to_owned())
+    }
+}
+
+impl Default for PlatformNotSupportedError {
+    fn default() -> Self {
+        Self {
+            message: "Platform not supported.".to_string(),
+        }
+    }
+}
+
+impl Error for PlatformNotSupportedError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        None
+    }
+}
+
+impl Display for PlatformNotSupportedError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl From<PlatformNotSupportedError> for ResultError {
+    fn from(err: PlatformNotSupportedError) -> Self {
+        ResultError::with_kind(&err, ResultErrorKind::PlatformNotSupported)
+    }
+}

--- a/NoiseEngine.Native/src/interop/rendering/presentation/window_interop.rs
+++ b/NoiseEngine.Native/src/interop/rendering/presentation/window_interop.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use cgmath::Vector2;
 
 use crate::{
-    errors::invalid_operation::InvalidOperationError,
+    errors::platform_not_supported::PlatformNotSupportedError,
     interop::prelude::{InteropOption, InteropResult, InteropString},
     rendering::presentation::{input::InputData, window::Window, window_settings::WindowSettings},
 };
@@ -31,7 +31,7 @@ extern "C" fn rendering_presentation_window_interop_create(
 
     #[allow(unreachable_code)]
     InteropResult::with_err(
-        InvalidOperationError::with_str("Window is not supported on this device.").into(),
+        PlatformNotSupportedError::with_str("Window is not supported on this device.").into(),
     )
 }
 

--- a/NoiseEngine.Native/src/interop/result_error_kind.rs
+++ b/NoiseEngine.Native/src/interop/result_error_kind.rs
@@ -8,6 +8,7 @@ pub enum ResultErrorKind {
     InvalidOperation = 3,
     Overflow = 4,
     Argument = 5,
+    PlatformNotSupported = 6,
 
     GraphicsUniversal = 1000,
     GraphicsInstanceCreate = 1001,

--- a/NoiseEngine/Interop/ResultError.cs
+++ b/NoiseEngine/Interop/ResultError.cs
@@ -49,6 +49,7 @@ internal struct ResultError : IDisposable {
             ResultErrorKind.InvalidOperation => new InvalidOperationException(Message, innerException),
             ResultErrorKind.Overflow => new OverflowException(Message, innerException),
             ResultErrorKind.Argument => new ArgumentException(Message, innerException),
+            ResultErrorKind.PlatformNotSupported => new PlatformNotSupportedException(Message, innerException),
 
             ResultErrorKind.GraphicsUniversal => new GraphicsException(Message, innerException),
             ResultErrorKind.GraphicsInstanceCreate => new GraphicsInstanceCreateException(Message, innerException),

--- a/NoiseEngine/Interop/ResultErrorKind.cs
+++ b/NoiseEngine/Interop/ResultErrorKind.cs
@@ -7,6 +7,7 @@ internal enum ResultErrorKind : uint {
     InvalidOperation = 3,
     Overflow = 4,
     Argument = 5,
+    PlatformNotSupported = 6,
 
     GraphicsUniversal = 1000,
     GraphicsInstanceCreate = 1001,

--- a/NoiseEngine/Window.cs
+++ b/NoiseEngine/Window.cs
@@ -72,11 +72,8 @@ public class Window : IDisposable, ICameraRenderTarget, IReferenceCoutable {
 
         if (!WindowInterop.Create(Id, title, width, height, new WindowSettingsRaw(settings)).TryGetValue(
             out InteropHandle<Window> handle, out ResultError error
-        ))
-        {
-            Exception exception = error.ToException();
-            error.Dispose();
-            throw new PlatformNotSupportedException(exception.Message);
+        )) {
+            error.ThrowAndDispose();
         }
 
         Handle = handle;

--- a/NoiseEngine/Window.cs
+++ b/NoiseEngine/Window.cs
@@ -72,8 +72,11 @@ public class Window : IDisposable, ICameraRenderTarget, IReferenceCoutable {
 
         if (!WindowInterop.Create(Id, title, width, height, new WindowSettingsRaw(settings)).TryGetValue(
             out InteropHandle<Window> handle, out ResultError error
-        )) {
-            error.ThrowAndDispose();
+        ))
+        {
+            Exception exception = error.ToException();
+            error.Dispose();
+            throw new PlatformNotSupportedException(exception.Message);
         }
 
         Handle = handle;


### PR DESCRIPTION
Throw PlatformNotSupportedException instead of the InvalidOperationException in the Window's class constructor as was said in #242 