### PR TITLE
Fixed disposal of invalid memories and implemented OS Check Jit optimization

### DIFF
--- a/NoiseEngine/Common/MemoryHelper.cs
+++ b/NoiseEngine/Common/MemoryHelper.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace NoiseEngine.Common;
+
+/// <summary>
+/// Collection of utility helpers memory management.
+/// </summary>
+internal static class MemoryHelper
+{
+    public static nuint AlignmentOf<T>() where T : unmanaged
+    {
+        return (nuint)System.Runtime.InteropServices.Marshal.SizeOf<T>();
+    }
+    
+    public static bool IsDangling<T>(nuint address) where T: unmanaged => address == AlignmentOf<T>();
+}

--- a/NoiseEngine/Common/MemoryHelper.cs
+++ b/NoiseEngine/Common/MemoryHelper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿using System.Runtime.InteropServices;
 
 namespace NoiseEngine.Common;
 
@@ -7,10 +7,23 @@ namespace NoiseEngine.Common;
 /// </summary>
 internal static class MemoryHelper
 {
-    public static nuint AlignmentOf<T>() where T : unmanaged
-    {
-        return (nuint)System.Runtime.InteropServices.Marshal.SizeOf<T>();
-    }
     
-    public static bool IsDangling<T>(nuint address) where T: unmanaged => address == AlignmentOf<T>();
+    /// <summary>
+    /// Returns the alignment requirement (in bytes) of an unmanaged type.
+    /// </summary>
+    /// <typeparam name="T">The unmanaged type for which to determine the alignment.</typeparam>
+    /// <returns>The alignment requirement (in bytes) of the specified unmanaged type.</returns>
+    public static nuint AlignmentOf<T>() where T : unmanaged {
+        return (nuint)Marshal.SizeOf<T>();
+    }
+
+    /// <summary>
+    /// Checks if the provided memory address is considered dangling for a specified unmanaged type.
+    /// </summary>
+    /// <typeparam name="T">The unmanaged type for which to perform the check.</typeparam>
+    /// <param name="address">The memory address to check.</param>
+    /// <returns>True if the memory address is equal to the alignment requirement of the specified unmanaged type; otherwise, false.</returns>
+    public static bool IsDangling<T>(nuint address) where T : unmanaged {
+        return address == AlignmentOf<T>();    
+    }
 }

--- a/NoiseEngine/Common/MemoryHelper.cs
+++ b/NoiseEngine/Common/MemoryHelper.cs
@@ -5,8 +5,7 @@ namespace NoiseEngine.Common;
 /// <summary>
 /// Collection of utility helpers memory management.
 /// </summary>
-internal static class MemoryHelper
-{
+internal static class MemoryHelper {
     
     /// <summary>
     /// Returns the alignment requirement (in bytes) of an unmanaged type.
@@ -26,4 +25,5 @@ internal static class MemoryHelper
     public static bool IsDangling<T>(nuint address) where T : unmanaged {
         return address == AlignmentOf<T>();    
     }
+    
 }

--- a/NoiseEngine/Diagnostics/MemoryInfo.cs
+++ b/NoiseEngine/Diagnostics/MemoryInfo.cs
@@ -48,10 +48,10 @@ public static class MemoryInfo {
     }
 
     private static nuint GetAvailablePhysicalMemory() {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+        if (OperatingSystem.IsWindows()) {
             PerformanceInformation information = GetWindowsPerformanceInfo();
             return information.PhysicalAvailable * information.PageSize;
-        } else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) {
+        } else if (OperatingSystem.IsLinux()) {
             return GetLinuxMemoryInfo("MemFree");
         }
 

--- a/NoiseEngine/Diagnostics/MemoryInfo.cs
+++ b/NoiseEngine/Diagnostics/MemoryInfo.cs
@@ -17,10 +17,10 @@ public static class MemoryInfo {
         (float)(AvailablePhysicalMemory / (decimal)TotalPhysicalMemory);
 
     static MemoryInfo() {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+        if (OperatingSystem.IsWindows()) {
             PerformanceInformation information = GetWindowsPerformanceInfo();
             TotalPhysicalMemory = information.PhysicalTotal * information.PageSize;
-        } else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) {
+        } else if (OperatingSystem.IsLinux()) {
             TotalPhysicalMemory = GetLinuxMemoryInfo("MemTotal");
         } else {
             throw new NotImplementedException();

--- a/NoiseEngine/Interop/InteropArray.cs
+++ b/NoiseEngine/Interop/InteropArray.cs
@@ -131,7 +131,7 @@ public struct InteropArray<T> : IDisposable, IReadOnlyList<T> where T : unmanage
     /// Disposes this object.
     /// </summary>
     public unsafe void Dispose() {
-        if (pointer == null || Length <= 0 && MemoryHelper.IsDangling<T>((nuint)pointer))
+        if (pointer == null || (Length == 0 && MemoryHelper.IsDangling<T>((nuint)pointer)))
             return;
 
         NativeMemory.AlignedFree(pointer);

--- a/NoiseEngine/Interop/InteropArray.cs
+++ b/NoiseEngine/Interop/InteropArray.cs
@@ -131,7 +131,7 @@ public struct InteropArray<T> : IDisposable, IReadOnlyList<T> where T : unmanage
     /// Disposes this object.
     /// </summary>
     public unsafe void Dispose() {
-        if (pointer == null || Length <= 0 || MemoryHelper.IsDangling<T>((nuint)pointer))
+        if (pointer == null || Length <= 0 && MemoryHelper.IsDangling<T>((nuint)pointer))
             return;
 
         NativeMemory.AlignedFree(pointer);

--- a/NoiseEngine/Interop/InteropArray.cs
+++ b/NoiseEngine/Interop/InteropArray.cs
@@ -131,7 +131,7 @@ public struct InteropArray<T> : IDisposable, IReadOnlyList<T> where T : unmanage
     /// Disposes this object.
     /// </summary>
     public unsafe void Dispose() {
-        if (pointer == null || MemoryHelper.IsDangling<T>((nuint)pointer) || Length <= 0)
+        if (pointer == null || Length <= 0 || MemoryHelper.IsDangling<T>((nuint)pointer))
             return;
 
         NativeMemory.AlignedFree(pointer);

--- a/NoiseEngine/Interop/InteropArray.cs
+++ b/NoiseEngine/Interop/InteropArray.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using NoiseEngine.Common;
 
 namespace NoiseEngine.Interop;
 
@@ -130,7 +131,7 @@ public struct InteropArray<T> : IDisposable, IReadOnlyList<T> where T : unmanage
     /// Disposes this object.
     /// </summary>
     public unsafe void Dispose() {
-        if (pointer == null)
+        if (pointer == null || MemoryHelper.IsDangling<T>((nuint)pointer) || Length <= 0)
             return;
 
         NativeMemory.AlignedFree(pointer);


### PR DESCRIPTION
Closes #352 and #70

Added `NoiseEngine.Common.MemoryHelper`, could add tests however these methods just use System's methods.